### PR TITLE
Align macOS validation with support policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,17 @@ jobs:
   test_installation:
     strategy:
       matrix:
-        macos: [macos-15-intel, macos-15]
+        # Apple currently ships security updates for macOS Sonoma 14, Sequoia 15,
+        # and Tahoe 26:
+        # https://support.apple.com/en-us/100100
+        #
+        # GitHub-hosted standard runners are available for macos-14 / macos-15 /
+        # macos-26 on Apple silicon and macos-15-intel / macos-26-intel on Intel:
+        # https://docs.github.com/en/actions/reference/runners/github-hosted-runners
+        #
+        # Validate the oldest supported Apple-silicon target, the currently
+        # available Intel target, and the latest Apple-silicon target.
+        macos: [macos-14, macos-15-intel, macos-26]
     runs-on: ${{ matrix.macos }}
     steps:
       - name: Checkout

--- a/.github/workflows/prepare-release-update.yml
+++ b/.github/workflows/prepare-release-update.yml
@@ -49,7 +49,8 @@ jobs:
     needs: resolve
     strategy:
       matrix:
-        macos: [macos-15-intel, macos-15]
+        # Keep the rehearsal matrix aligned with the support policy in ci.yml.
+        macos: [macos-14, macos-15-intel, macos-26]
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
- validate Homebrew installation on macOS 14, macOS 15 Intel, and macOS 26
- keep the dry-run rehearsal matrix aligned with the same support policy
- document the support-period rationale with links to Apple and GitHub official docs

## Why
The next Homebrew release should be validated against the oldest still-supported Apple-silicon release, an available Intel runner, and the latest Apple-silicon release.
